### PR TITLE
Baseline tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 js/ux-capture.min.js
+coverage

--- a/js/ux-capture.js
+++ b/js/ux-capture.js
@@ -8,6 +8,8 @@
     // prepare base UX Capture object
     if (typeof window.UX === "undefined") {
       window.UX = {};
+    } else {
+      return window.UX;
     }
 
     const isUserTimingSupported =
@@ -40,6 +42,10 @@
      * @TODO re-evaluate if we should allow multiple executions of this method
      */
     window.UX.expect = function(zones) {
+      if (typeof zones === "undefined" || !Array.isArray(zones)) {
+        return false;
+      }
+
       expectedZones = zones.map(zone => {
         // only create promises if zone contains any marks, otherwise just ignore it
         if (zone.marks && zone.marks.length > 0) {
@@ -83,9 +89,9 @@
               })
           );
 
-          // only if all marks were recorded (and promises resolved), go ahead and record the measure ending with last recorded mark
-          Promise.all(promises).then(() => {
-            if (isUserTimingSupported) {
+          if (isUserTimingSupported) {
+            // only if all marks were recorded (and promises resolved), go ahead and record the measure ending with last recorded mark
+            Promise.all(promises).then(() => {
               // record a measure using W3C User Timing API
               window.performance.measure(
                 zone.label,
@@ -97,8 +103,8 @@
               if (onMeasure) {
                 onMeasure(zone.label);
               }
-            }
-          });
+            });
+          }
 
           return zone;
         }
@@ -120,10 +126,14 @@
 
       if (typeof configuration.onMark === "function") {
         onMark = configuration.onMark;
+      } else {
+        onMark = null;
       }
 
       if (typeof configuration.onMeasure === "function") {
         onMeasure = configuration.onMeasure;
+      } else {
+        onMeasure = null;
       }
     };
 

--- a/js/ux-capture.js
+++ b/js/ux-capture.js
@@ -5,12 +5,12 @@
       window = {};
     }
 
-    // prepare base UX Capture object
-    if (typeof window.UX === "undefined") {
-      window.UX = {};
-    } else {
+    // already have UX Capture object defined, reuse it
+    if (typeof window.UX !== "undefined") {
       return window.UX;
     }
+
+    window.UX = {};
 
     const isUserTimingSupported =
       typeof window.performance !== "undefined" &&

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "build": "babel js/ux-capture.js | uglifyjs >js/ux-capture.min.js",
     "build:clean": "rm js/ux-capture.min.js",
     "test": "jest test/*.test.js",
-    "test:watch": "jest test/*.test.js --watch --verbose"
+    "test:watch": "jest test/*.test.js --watch --verbose --coverage",
+    "test:coverage": "jest test/*.test.js --coverage"
   },
   "author": "Sergey Chernyshev",
   "license": "MIT",

--- a/test/compat.test.js
+++ b/test/compat.test.js
@@ -19,7 +19,7 @@ describe("Compatibility", () => {
     }).not.toThrow();
   });
 
-  it("Should not throw an error when called with", () => {
+  it("Should not throw an error when window.UX is already defined", () => {
     expect(() => {
       require("../js/ux-capture")(window);
       require("../js/ux-capture")(window);

--- a/test/compat.test.js
+++ b/test/compat.test.js
@@ -1,0 +1,28 @@
+// set up global UX object without a window
+const UX = require("../js/ux-capture")();
+
+const MOCK_MEASURE_1 = "ux-mock-measure_1";
+const MOCK_MARK_1_1 = "ux-mock-mark_1_1";
+const MOCK_MARK_1_2 = "ux-mock-mark_1_2";
+
+describe("Compatibility", () => {
+  UX.expect([
+    {
+      label: MOCK_MEASURE_1,
+      marks: [MOCK_MARK_1_1, MOCK_MARK_1_2]
+    }
+  ]);
+
+  it("UX.mark() must not throw an error if UserTiming API is not available", () => {
+    expect(() => {
+      UX.mark(MOCK_MARK_1_1);
+    }).not.toThrow();
+  });
+
+  it("Should not throw an error when called with", () => {
+    expect(() => {
+      require("../js/ux-capture")(window);
+      require("../js/ux-capture")(window);
+    }).not.toThrow();
+  });
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,126 @@
+// UserTiming polyfill to override broken jsdom performance API
+window.performance = require("usertiming");
+
+// faking navigation timing API's navigationStart (not polyfilled by UserTiming polyfill)
+window.performance.timing = {
+  navigationStart: window.performance.now()
+};
+
+// using console.timeStamp for testing only
+console.timeStamp = jest.fn();
+
+// set up global UX object
+const UX = require("../js/ux-capture")(window);
+
+const MOCK_MEASURE_1 = "ux-mock-measure_1";
+const MOCK_MARK_1_1 = "ux-mock-mark_1_1";
+const MOCK_MARK_1_2 = "ux-mock-mark_1_2";
+
+const MOCK_MEASURE_2 = "ux-mock-measure_2";
+const MOCK_MARK_2_1 = "ux-mock-mark_2_1";
+
+const MOCK_MEASURE_3 = "ux-mock-measure_3";
+const MOCK_MARK_3_1 = "ux-mock-mark_3_1";
+
+const MOCK_MEASURE_4 = "ux-mock-measure_4";
+const MOCK_MARK_4_1 = "ux-mock-mark_4_1";
+
+const MOCK_MEASURE_5 = "ux-mock-measure_5";
+const MOCK_MARK_5_1 = "ux-mock-mark_5_1";
+
+describe("UX.config()", () => {
+  UX.expect([
+    {
+      label: MOCK_MEASURE_1,
+      marks: [MOCK_MARK_1_1, MOCK_MARK_1_2]
+    },
+    {
+      label: MOCK_MEASURE_2,
+      marks: [MOCK_MARK_2_1]
+    },
+    {
+      label: MOCK_MEASURE_3,
+      marks: [MOCK_MARK_3_1]
+    },
+    {
+      label: MOCK_MEASURE_4,
+      marks: [MOCK_MARK_4_1]
+    },
+    {
+      label: MOCK_MEASURE_5,
+      marks: [MOCK_MARK_5_1]
+    }
+  ]);
+
+  const mockOnMarkCallback = jest.fn();
+  const mockOnMeasureCallback = jest.fn();
+
+  it("Should not break if non-object is passed", () => {
+    expect(() => {
+      UX.config();
+    }).not.toThrow();
+
+    expect(() => {
+      UX.config("");
+    }).not.toThrow();
+  });
+
+  it("Should be able to configure onMark handler", () => {
+    mockOnMarkCallback.mockClear();
+
+    UX.config({ onMark: mockOnMarkCallback });
+
+    UX.mark(MOCK_MARK_1_1);
+
+    expect(mockOnMarkCallback).toHaveBeenCalledWith(MOCK_MARK_1_1);
+  });
+
+  it("Should be able to configure onMeasure handler", done => {
+    mockOnMeasureCallback.mockClear();
+
+    UX.config({ onMeasure: mockOnMeasureCallback });
+
+    UX.mark(MOCK_MARK_2_1);
+
+    // use setTimeout to release thread for Promise.all() to fire for measures.
+    setTimeout(() => {
+      expect(mockOnMeasureCallback).toHaveBeenCalledWith(MOCK_MEASURE_2);
+      done();
+    }, 0);
+  });
+
+  it("Should remove custom onMark callback if it's not defined on configuration object", () => {
+    // configure onMark callback
+    UX.config({ onMark: mockOnMarkCallback });
+
+    // remove onMark callback
+    UX.config({});
+
+    mockOnMarkCallback.mockClear();
+
+    UX.mark(MOCK_MARK_3_1);
+
+    expect(mockOnMarkCallback).not.toHaveBeenCalledWith(MOCK_MARK_3_1);
+  });
+
+  it("Should remove custom onMeasure callback if it's not defined on configuration object", done => {
+    // configured onMeasure callback
+    UX.config({ onMeasure: mockOnMeasureCallback });
+
+    // remove onMeasure callback
+    UX.config({ onMark: mockOnMarkCallback });
+
+    mockOnMarkCallback.mockClear();
+    mockOnMeasureCallback.mockClear();
+
+    UX.mark(MOCK_MARK_4_1);
+
+    expect(mockOnMarkCallback).toHaveBeenCalledWith(MOCK_MARK_4_1);
+
+    // use setTimeout to release thread for Promise.all() to fire for measures.
+    setTimeout(() => {
+      expect(mockOnMeasureCallback).not.toHaveBeenCalledWith(MOCK_MEASURE_4);
+      done();
+    }, 0);
+  });
+});

--- a/test/expect.test.js
+++ b/test/expect.test.js
@@ -1,0 +1,67 @@
+// UserTiming polyfill to override broken jsdom performance API
+window.performance = require("usertiming");
+
+// faking navigation timing API's navigationStart (not polyfilled by UserTiming polyfill)
+window.performance.timing = {
+  navigationStart: window.performance.now()
+};
+
+// using console.timeStamp for testing only
+console.timeStamp = jest.fn();
+
+// set up global UX object
+const UX = require("../js/ux-capture")(window);
+
+const MOCK_MEASURE_1 = "ux-mock-measure_1";
+const MOCK_MARK_1_1 = "ux-mock-mark_1_1";
+const MOCK_MARK_1_2 = "ux-mock-mark_1_2";
+
+describe("UX.expect()", () => {
+  it("must create dependencies between marks and measures using promises", () => {
+    UX.expect([
+      {
+        label: MOCK_MEASURE_1,
+        marks: [MOCK_MARK_1_1, MOCK_MARK_1_2]
+      }
+    ]);
+
+    UX.mark(MOCK_MARK_1_1);
+
+    expect(
+      window.performance
+        .getEntriesByType("mark")
+        .find(mark => mark.name === MOCK_MARK_1_1)
+    ).toBeTruthy();
+  });
+
+  it("must not throw errors if no zones passed in", () => {
+    expect(() => {
+      UX.expect();
+    }).not.toThrow();
+  });
+
+  it("must not throw errors if empty zones list is passed in", () => {
+    expect(() => {
+      UX.expect([]);
+    }).not.toThrow();
+  });
+
+  it("should not trigger a measure when empty marks array is passed", done => {
+    const mockOnMeasureCallback = jest.fn();
+
+    UX.config({ onMeasure: mockOnMeasureCallback });
+
+    UX.expect([
+      {
+        label: MOCK_MEASURE_1,
+        marks: []
+      }
+    ]);
+
+    // use setTimeout to release thread for Promise.all() to fire for measures.
+    setTimeout(() => {
+      expect(mockOnMeasureCallback).not.toHaveBeenCalled();
+      done();
+    }, 0);
+  });
+});

--- a/test/mark.test.js
+++ b/test/mark.test.js
@@ -1,0 +1,86 @@
+// UserTiming polyfill to override broken jsdom performance API
+window.performance = require("usertiming");
+
+// faking navigation timing API's navigationStart (not polyfilled by UserTiming polyfill)
+window.performance.timing = {
+  navigationStart: window.performance.now()
+};
+
+// using console.timeStamp for testing only
+console.timeStamp = jest.fn();
+
+// set up global UX object
+const UX = require("../js/ux-capture")(window);
+
+const MOCK_MEASURE_1 = "ux-mock-measure_1";
+const MOCK_MARK_1_1 = "ux-mock-mark_1_1";
+const MOCK_MARK_1_2 = "ux-mock-mark_1_2";
+
+const MOCK_UNEXPECTED_MARK = "ux-unexpected-mark";
+
+describe("UX.mark()", () => {
+  const mockOnMarkCallback = jest.fn();
+
+  UX.expect([
+    {
+      label: MOCK_MEASURE_1,
+      marks: [MOCK_MARK_1_1, MOCK_MARK_1_2]
+    }
+  ]);
+
+  it("must mark user timing api timeline", () => {
+    UX.mark(MOCK_MARK_1_1);
+
+    expect(
+      window.performance
+        .getEntriesByType("mark")
+        .find(mark => mark.name === MOCK_MARK_1_1)
+    ).toBeTruthy();
+  });
+
+  it("should trigger recording of a measure if last mark in chain", done => {
+    UX.mark(MOCK_MARK_1_2);
+
+    // use setTimeout to release thread for Promise.all() to fire for measures.
+    setTimeout(() => {
+      expect(
+        window.performance
+          .getEntriesByType("measure")
+          .find(mark => mark.name === MOCK_MEASURE_1)
+      ).toBeTruthy();
+      done();
+    }, 0);
+  });
+
+  it("should fire a console.timeStamp it is available", () => {
+    console.timeStamp.mockClear();
+
+    UX.mark(MOCK_MARK_1_1);
+
+    expect(console.timeStamp).toHaveBeenCalledWith(MOCK_MARK_1_1);
+  });
+
+  it("should call a custom mark callback when provided", () => {
+    mockOnMarkCallback.mockClear();
+
+    UX.config({ onMark: mockOnMarkCallback });
+
+    UX.mark(MOCK_MARK_1_1);
+
+    expect(mockOnMarkCallback).toHaveBeenCalledWith(MOCK_MARK_1_1);
+  });
+
+  it("should not record a mark that is not expected", () => {
+    mockOnMarkCallback.mockClear();
+
+    UX.mark(MOCK_UNEXPECTED_MARK);
+
+    expect(
+      window.performance
+        .getEntriesByType("mark")
+        .find(mark => mark.name === MOCK_UNEXPECTED_MARK)
+    ).not.toBeTruthy();
+  });
+
+  // it("should not fire native mark if UserTiming api is not available", () => {});
+});

--- a/test/ux-capture.test.js
+++ b/test/ux-capture.test.js
@@ -12,73 +12,9 @@ console.timeStamp = jest.fn();
 // set up global UX object
 const UX = require("../js/ux-capture")(window);
 
-const MOCK_MEASURE_1 = "ux-mock-measure_1";
-const MOCK_MARK_1_1 = "ux-mock-mark_1_1";
-const MOCK_MARK_1_2 = "ux-mock-mark_1_2";
-
-const MOCK_MEASURE_2 = "ux-mock-measure_2";
-const MOCK_MARK_2_1 = "ux-mock-mark_2_1";
-
 describe("UX Capture", () => {
   it("should be available as UX global variable", () => {
     expect(UX);
-  });
-
-  UX.expect([
-    {
-      label: MOCK_MEASURE_1,
-      marks: [MOCK_MARK_1_1, MOCK_MARK_1_2]
-    },
-    {
-      label: MOCK_MEASURE_2,
-      marks: [MOCK_MARK_2_1]
-    }
-  ]);
-
-  describe("UX.mark()", () => {
-    it("must mark user timing api timeline", () => {
-      UX.mark(MOCK_MARK_1_1);
-
-      expect(
-        window.performance
-          .getEntriesByType("mark")
-          .find(mark => mark.name === MOCK_MARK_1_1)
-      ).toBeTruthy();
-    });
-
-    it("should trigger recording of a measure if last mark in chain", done => {
-      UX.mark(MOCK_MARK_1_2);
-
-      // use setTimeout to release thread for Promise.all() to fire for measures.
-      setTimeout(() => {
-        expect(
-          window.performance
-            .getEntriesByType("measure")
-            .find(mark => mark.name === MOCK_MEASURE_1)
-        ).toBeTruthy();
-        done();
-      }, 0);
-    });
-
-    it("should fire a console.timeStamp it is available", () => {
-      console.timeStamp.mockClear();
-
-      UX.mark(MOCK_MARK_1_1);
-
-      expect(console.timeStamp).toHaveBeenCalledWith(MOCK_MARK_1_1);
-    });
-
-    it("should call a custom mark callback when provided", () => {
-      const mockOnMarkCallback = jest.fn();
-
-      UX.config({ onMark: mockOnMarkCallback });
-
-      UX.mark(MOCK_MARK_1_1);
-
-      expect(mockOnMarkCallback).toHaveBeenCalledWith(MOCK_MARK_1_1);
-    });
-
-    // it("should not fire native mark if UserTiming api is not available", () => {});
   });
 
   describe("Measures", () => {

--- a/test/ux-capture.test.js
+++ b/test/ux-capture.test.js
@@ -6,11 +6,18 @@ window.performance.timing = {
   navigationStart: window.performance.now()
 };
 
+// using console.timeStamp for testing only
+console.timeStamp = jest.fn();
+
 // set up global UX object
 const UX = require("../js/ux-capture")(window);
 
-const MOCK_MARK_LABEL = "ux-mock-mark";
-const MOCK_MEASURE_LABEL = "ux-mock-measure";
+const MOCK_MEASURE_1 = "ux-mock-measure_1";
+const MOCK_MARK_1_1 = "ux-mock-mark_1_1";
+const MOCK_MARK_1_2 = "ux-mock-mark_1_2";
+
+const MOCK_MEASURE_2 = "ux-mock-measure_2";
+const MOCK_MARK_2_1 = "ux-mock-mark_2_1";
 
 describe("UX Capture", () => {
   it("should be available as UX global variable", () => {
@@ -19,20 +26,67 @@ describe("UX Capture", () => {
 
   UX.expect([
     {
-      label: MOCK_MEASURE_LABEL,
-      marks: [MOCK_MARK_LABEL]
+      label: MOCK_MEASURE_1,
+      marks: [MOCK_MARK_1_1, MOCK_MARK_1_2]
+    },
+    {
+      label: MOCK_MEASURE_2,
+      marks: [MOCK_MARK_2_1]
     }
   ]);
 
   describe("UX.mark()", () => {
     it("must mark user timing api timeline", () => {
-      UX.mark(MOCK_MARK_LABEL);
+      UX.mark(MOCK_MARK_1_1);
 
       expect(
         window.performance
           .getEntriesByType("mark")
-          .filter(mark => mark.name === MOCK_MARK_LABEL).length
-      ).toBe(1);
+          .find(mark => mark.name === MOCK_MARK_1_1)
+      ).toBeTruthy();
     });
+
+    it("should trigger recording of a measure if last mark in chain", done => {
+      UX.mark(MOCK_MARK_1_2);
+
+      // use setTimeout to release thread for Promise.all() to fire for measures.
+      setTimeout(() => {
+        expect(
+          window.performance
+            .getEntriesByType("measure")
+            .find(mark => mark.name === MOCK_MEASURE_1)
+        ).toBeTruthy();
+        done();
+      }, 0);
+    });
+
+    it("should fire a console.timeStamp it is available", () => {
+      console.timeStamp.mockClear();
+
+      UX.mark(MOCK_MARK_1_1);
+
+      expect(console.timeStamp).toHaveBeenCalledWith(MOCK_MARK_1_1);
+    });
+
+    it("should call a custom mark callback when provided", () => {
+      const mockOnMarkCallback = jest.fn();
+
+      UX.config({ onMark: mockOnMarkCallback });
+
+      UX.mark(MOCK_MARK_1_1);
+
+      expect(mockOnMarkCallback).toHaveBeenCalledWith(MOCK_MARK_1_1);
+    });
+
+    // it("should not fire native mark if UserTiming api is not available", () => {});
   });
+
+  describe("Measures", () => {
+    // it("Must wait for all marks declared", () => {});
+    // it("must end with the latest mark and start with 0", () => {});
+  });
+
+  // ???????????
+  // Must fire a native mark even if it is not expected? (Should this be supported? Should we use it for technical marking? Not sure)
+  // ??? Should fire custom callbacks even if UserTiming api is not supported? Is that true? How will it measure time? Should be available though a polyfill instead?
 });


### PR DESCRIPTION
Tests for existing code.

Currently, library doesn't support resetting itself (or timing plane) so I split the tests into separate test cases which get new window object. I also had to write individual assertions carefully so they do not conflict with each other, e.g. operate on different marks and measures when necessary.

Also added test coverage reporting and tried to cover all the code with exception of AMD and browser loaders.