### PR TITLE
WP 843 Wait for next paint

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
+  "plugins": ["@babel/plugin-proposal-class-properties"],
   "presets": [
     ["@babel/preset-env", { "targets": { "browsers": ["last 2 versions"] } }]
   ]

--- a/js/src/ExpectedMark.js
+++ b/js/src/ExpectedMark.js
@@ -59,10 +59,10 @@ export default class ExpectedMark {
       window.console.timeStamp("[DEBUG] original call for " + this.name);
     }
 
-    window.requestAnimationFrame(() => setTimeout(() => this.record()));
+    window.requestAnimationFrame(() => setTimeout(this.record));
   }
 
-  record() {
+  record = () => {
     if (
       typeof window.performance !== "undefined" &&
       typeof window.performance.measure !== "undefined"
@@ -92,5 +92,5 @@ export default class ExpectedMark {
     this.onMarkListeners.forEach(onCompleteListener =>
       onCompleteListener(this)
     );
-  }
+  };
 }

--- a/js/src/ExpectedMark.js
+++ b/js/src/ExpectedMark.js
@@ -41,6 +41,24 @@ export default class ExpectedMark {
     this.onMarkListeners.push(onMark);
   }
 
+  /**
+   * This method tries to approximate full rendering lifecycle in the browser
+   * rather than just measuring JS execution like render() method does.
+   *
+   * See Nolan Lawson's article describing the issue and proposing this method:
+   * https://nolanlawson.com/2018/09/25/accurately-measuring-layout-on-the-web/
+   */
+  waitForNextPaintAndRecord() {
+    if (
+      typeof window.console !== "undefined" &&
+      typeof window.console.timeStamp !== "undefined"
+    ) {
+      window.console.timeStamp("original call for " + this.name);
+    }
+
+    window.requestAnimationFrame(() => setTimeout(() => this.record()));
+  }
+
   record() {
     if (
       typeof window.performance !== "undefined" &&

--- a/js/src/ExpectedMark.js
+++ b/js/src/ExpectedMark.js
@@ -49,11 +49,14 @@ export default class ExpectedMark {
    * https://nolanlawson.com/2018/09/25/accurately-measuring-layout-on-the-web/
    */
   waitForNextPaintAndRecord() {
+    // In development mode, include DEBUG timestamps to show when
+    // original calls were fired to see the impact
     if (
+      process.env.NODE_ENV !== "production" &&
       typeof window.console !== "undefined" &&
       typeof window.console.timeStamp !== "undefined"
     ) {
-      window.console.timeStamp("original call for " + this.name);
+      window.console.timeStamp("[DEBUG] original call for " + this.name);
     }
 
     window.requestAnimationFrame(() => setTimeout(() => this.record()));

--- a/js/src/UXCapture.js
+++ b/js/src/UXCapture.js
@@ -33,11 +33,15 @@ export default class UXCapture {
     });
   }
 
-  mark(name) {
+  mark(name, waitForNextPaint = true) {
     const mark = ExpectedMark.get(name);
 
     if (mark) {
-      mark.record();
+      if (waitForNextPaint) {
+        mark.waitForNextPaintAndRecord();
+      } else {
+        mark.record();
+      }
     }
   }
 

--- a/js/src/UXCapture.js
+++ b/js/src/UXCapture.js
@@ -33,6 +33,17 @@ export default class UXCapture {
     });
   }
 
+  /**
+   * Creates marks on UserTiming timeline.
+   * It also creates UserTiming measures for each zone if mark is last one to be recorded in the zone.
+   *
+   * waitForNextPaint attribute can be set to false if your code is not expected to change any visual
+   * elements of UI and trigger repaints. A good example is attaching click event handlers to elements
+   * which is need for them to be interactive, but by itself doesn't affect element's appearance.
+   *
+   * @param {string} name
+   * @param {boolean} waitForNextPaint
+   */
   mark(name, waitForNextPaint = true) {
     const mark = ExpectedMark.get(name);
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.1",
     "@babel/preset-env": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.0",
     "babel-jest": "^23.6.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-loader": "^2.1.1",
     "eslint-plugin-prettier": "^2.6.2",
     "jest": "^23.6.0",
+    "semver": "^5.6.0",
     "uglify-es": "^3.3.9",
     "usertiming": "^0.1.8",
     "webpack": "^4.18.1",

--- a/test/compat.test.js
+++ b/test/compat.test.js
@@ -14,6 +14,11 @@ describe("Compatibility", () => {
     }
   ]);
 
+  // this effectively removes asynchronicity from UX.mark() which
+  // uses rAF->setTimeout->mark.record() chain
+  jest.spyOn(window, "requestAnimationFrame").mockImplementation(cb => cb());
+  jest.spyOn(window, "setTimeout").mockImplementation(cb => cb());
+
   it("UX.mark() must not throw an error if UserTiming API is not available", () => {
     expect(() => {
       UX.mark(MOCK_MARK_1_1);

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -56,6 +56,11 @@ describe("UX.config()", () => {
   const mockOnMarkCallback = jest.fn();
   const mockOnMeasureCallback = jest.fn();
 
+  // this effectively removes asynchronicity from UX.mark() which
+  // uses rAF->setTimeout->mark.record() chain
+  jest.spyOn(window, "requestAnimationFrame").mockImplementation(cb => cb());
+  jest.spyOn(window, "setTimeout").mockImplementation(cb => cb());
+
   it("Should throw an error if non-object is passed", () => {
     expect(() => {
       UX.config();

--- a/test/expect.test.js
+++ b/test/expect.test.js
@@ -26,6 +26,11 @@ describe("UX.expect()", () => {
       }
     ]);
 
+    // this effectively removes asynchronicity from UX.mark() which
+    // uses rAF->setTimeout->mark.record() chain
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation(cb => cb());
+    jest.spyOn(window, "setTimeout").mockImplementation(cb => cb());
+
     UX.mark(MOCK_MARK_1_1);
 
     expect(

--- a/test/expect_legacy.test.js
+++ b/test/expect_legacy.test.js
@@ -1,0 +1,105 @@
+// UserTiming polyfill to override broken jsdom performance API
+window.performance = require("usertiming");
+
+// faking navigation timing API's navigationStart (not polyfilled by UserTiming polyfill)
+window.performance.timing = {
+  navigationStart: window.performance.now()
+};
+
+// set up global UX object
+const UXCapture = require("../js/src/ux-capture");
+const UX = new UXCapture();
+
+const MOCK_MEASURE_1 = "ux-mock-measure_1";
+const MOCK_MARK_1_1 = "ux-mock-mark_1_1";
+
+const MOCK_MEASURE_2_LABEL = "ux-mock-measure_2_label";
+const MOCK_MEASURE_2_NAME = "ux-mock-measure_2_name";
+const MOCK_MARK_2_1 = "ux-mock-mark_2_1";
+
+console.warn = jest.fn();
+
+describe("UX.expect() legacy support until version 3.0.0", () => {
+  it("must work with legacy `label` key instead of new `name` key", () => {
+    UX.expect([
+      {
+        label: MOCK_MEASURE_1,
+        marks: [MOCK_MARK_1_1]
+      }
+    ]);
+
+    // this effectively removes asynchronicity from UX.mark() which
+    // uses rAF->setTimeout->mark.record() chain
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation(cb => cb());
+    jest.spyOn(window, "setTimeout").mockImplementation(cb => cb());
+
+    UX.mark(MOCK_MARK_1_1);
+
+    expect(
+      window.performance
+        .getEntriesByType("mark")
+        .find(mark => mark.name === MOCK_MARK_1_1)
+    ).toBeTruthy();
+  });
+
+  it("must throw a warning when `label` is used", () => {
+    console.warn.mockClear();
+
+    UX.expect([
+      {
+        label: MOCK_MEASURE_1,
+        marks: [MOCK_MARK_1_1]
+      }
+    ]);
+
+    // this effectively removes asynchronicity from UX.mark() which
+    // uses rAF->setTimeout->mark.record() chain
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation(cb => cb());
+    jest.spyOn(window, "setTimeout").mockImplementation(cb => cb());
+
+    UX.mark(MOCK_MARK_1_1);
+
+    expect(
+      window.performance
+        .getEntriesByType("mark")
+        .find(mark => mark.name === MOCK_MARK_1_1)
+    ).toBeTruthy();
+
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("must not override `name` key if legacy `label` key is used", () => {
+    UX.expect([
+      {
+        label: MOCK_MEASURE_2_LABEL,
+        name: MOCK_MEASURE_2_NAME,
+        marks: [MOCK_MARK_2_1]
+      }
+    ]);
+
+    // this effectively removes asynchronicity from UX.mark() which
+    // uses rAF->setTimeout->mark.record() chain
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation(cb => cb());
+    jest.spyOn(window, "setTimeout").mockImplementation(cb => cb());
+
+    UX.mark(MOCK_MARK_2_1);
+
+    expect(
+      window.performance
+        .getEntriesByType("mark")
+        .find(mark => mark.name === MOCK_MARK_2_1)
+    ).toBeTruthy();
+
+    expect(
+      window.performance
+        .getEntriesByType("measure")
+        .find(mark => mark.name === MOCK_MEASURE_2_NAME)
+    ).toBeTruthy();
+
+    expect(
+      window.performance
+        .getEntriesByType("measure")
+        .find(mark => mark.name === MOCK_MEASURE_2_LABEL)
+    ).not.toBeTruthy();
+  });
+});

--- a/test/expect_legacy.test.js
+++ b/test/expect_legacy.test.js
@@ -17,9 +17,16 @@ const MOCK_MEASURE_2_LABEL = "ux-mock-measure_2_label";
 const MOCK_MEASURE_2_NAME = "ux-mock-measure_2_name";
 const MOCK_MARK_2_1 = "ux-mock-mark_2_1";
 
+const semver = require("semver");
+const MODULE_VERSION = require("../package.json").version;
+
 console.warn = jest.fn();
 
 describe("UX.expect() legacy support until version 3.0.0", () => {
+  it("support must only be kept until v3.0.0", () => {
+    expect(semver.lt(MODULE_VERSION, "3.0.0")).toBeTruthy();
+  });
+
   it("must work with legacy `label` key instead of new `name` key", () => {
     UX.expect([
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,6 +201,17 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.0.0"
 
+"@babel/plugin-proposal-class-properties@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz#9af01856b1241db60ec8838d84691aa0bd1e8df4"
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+    "@babel/plugin-syntax-class-properties" "^7.0.0"
+
 "@babel/plugin-proposal-json-strings@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz#3b4d7b5cf51e1f2e70f52351d28d44fc2970d01e"
@@ -233,6 +244,12 @@
 "@babel/plugin-syntax-async-generators@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz#bf0891dcdbf59558359d0c626fdc9490e20bc13c"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-class-properties@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz#e051af5d300cbfbcec4a7476e37a803489881634"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4506,6 +4506,10 @@ schema-utils@^0.4.4, schema-utils@^0.4.5:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
+semver@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+
 serialize-javascript@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.5.0.tgz#1aa336162c88a890ddad5384baebc93a655161fe"


### PR DESCRIPTION
This adds UX metrics precision optimization by waiting for next paint before firing UserTiming mark
See JIRA ticket for more details: https://meetup.atlassian.net/browse/WP-843

- Implemented new `waitForNextPaintAndRecord()` method to `ExpectedMark` class
- Made it to be default behavior for `UX.mark(name, waitForNextPaint = true)` call while override-able if second parameter is set to false.
- Fixed unit tests to work (disabled async nature of `requestAnimationFrame()` and `setTimeout()`

Also added tests for legacy configuration format support, including deprecation test.