### PR TITLE
Wp 823 start navigation

### DIFF
--- a/js/src/ExpectedMark.js
+++ b/js/src/ExpectedMark.js
@@ -65,7 +65,7 @@ export default class ExpectedMark {
   record = () => {
     if (
       typeof window.performance !== "undefined" &&
-      typeof window.performance.measure !== "undefined"
+      typeof window.performance.mark !== "undefined"
     ) {
       // record the mark using W3C User Timing API
       window.performance.mark(this.name);

--- a/js/src/UXCapture.js
+++ b/js/src/UXCapture.js
@@ -12,21 +12,22 @@ export default class UXCapture {
   }
 
   /**
-   * Sets expected marks and corresponding zones for current view
+   * Creates a new View instance and supplies expected marks and
+   * corresponding zones to the View.
    *
-   * @TODO re-evaluate if we should allow multiple executions of this method
+   * TODO: re-evaluate if we should allow multiple executions of this method
+   *
+   * @param {object} zoneConfigs
    */
   expect(zoneConfigs) {
-    // create a view object for initial, server-side rendered page view
+    // View object for initial, server-side rendered page view
     const pageView = new View({
-      // calling currently configured onMark & onMeasure handlers inside View's callbacks
-      // allows making UX.config() call after UX.expect() call
+      // `onMark` and `onMeasure` call `this.onMark` and `this.onMeasure`
+      // to handle cases where `UX.config()` comes after `UX.expect()`
       onMark: mark => {
-        // console.log(this.onMark);
         this.onMark(mark);
       },
       onMeasure: measure => {
-        // console.log(this.onMeasure);
         this.onMeasure(measure);
       },
       zoneConfigs
@@ -34,12 +35,14 @@ export default class UXCapture {
   }
 
   /**
-   * Creates marks on UserTiming timeline.
-   * It also creates UserTiming measures for each zone if mark is last one to be recorded in the zone.
+   * Creates marks on UserTiming timeline. Also creates UserTiming
+   * measures for each zone when last mark is recorded.
    *
-   * waitForNextPaint attribute can be set to false if your code is not expected to change any visual
-   * elements of UI and trigger repaints. A good example is attaching click event handlers to elements
-   * which is need for them to be interactive, but by itself doesn't affect element's appearance.
+   * `waitForNextPaint` should be set to false if your code is not
+   * expected to change any visual elements and trigger repaints.
+   *
+   * Example: click event handlers on elements are necessary
+   * for them to be interactive but don't affect the element's appearance.
    *
    * @param {string} name
    * @param {boolean} waitForNextPaint
@@ -56,8 +59,24 @@ export default class UXCapture {
     }
   }
 
+  /**
+   * Assigns user-specified `onMark` and `onMeasure` callbacks
+   * to UXCapture instance.
+   *
+   * @param {object} configuration
+   */
   config(configuration) {
     const { onMark = NOOP, onMeasure = NOOP } = configuration;
     Object.assign(this, { onMark, onMeasure });
+  }
+
+  /**
+   * Updates the `transition-start` mark. `transition-start` is
+   * the starting point for UserTiming measures within each subsequent
+   * Interactive View.
+   *
+   */
+  startTransition() {
+
   }
 }

--- a/js/src/UXCapture.js
+++ b/js/src/UXCapture.js
@@ -2,11 +2,14 @@ import ExpectedMark from "./ExpectedMark";
 import View from "./View";
 
 const NOOP = () => {};
+const INTERACTION_START_MARK = "interactionStart";
+const NAVIGATION_START_MARK = "navigationStart";
 
 export default class UXCapture {
   constructor() {
     this.onMark = NOOP;
     this.onMeasure = NOOP;
+    this.startMark = NAVIGATION_START_MARK;
 
     window.UX = this;
   }
@@ -30,7 +33,8 @@ export default class UXCapture {
       onMeasure: measure => {
         this.onMeasure(measure);
       },
-      zoneConfigs
+      startMark: this.startMark,
+      zoneConfigs,
     });
   }
 
@@ -66,8 +70,13 @@ export default class UXCapture {
    * @param {object} configuration
    */
   config(configuration) {
-    const { onMark = NOOP, onMeasure = NOOP } = configuration;
-    Object.assign(this, { onMark, onMeasure });
+    const { onMark = NOOP, onMeasure = NOOP, interactive = false } = configuration;
+
+    if (interactive) {
+      this.startMark = INTERACTION_START_MARK;
+    }
+
+    Object.assign(this, { onMark, onMeasure, startMark });
   }
 
   /**
@@ -77,6 +86,11 @@ export default class UXCapture {
    *
    */
   startTransition() {
-
+    if (
+      typeof window.performance !== "undefined" &&
+      typeof window.performance.mark !== "undefined"
+    ) {
+      window.performance.mark(INTERACTION_START_MARK);
+    }
   }
 }

--- a/js/src/View.js
+++ b/js/src/View.js
@@ -1,12 +1,16 @@
 import Zone from "./Zone";
 
 /**
- * View is a collection of zones representing one page view or interactive view
+ * A `View` is a collection of zones representing a single
+ * page view or interactive view.
+ *
+ * Refer to ux-capture README glossary for view definitions.
+ * @see: https://github.com/meetup/ux-capture#glossary
  */
 export default class View {
   constructor({ onMark, onMeasure, zoneConfigs }) {
     this.expectedZones = zoneConfigs.map(zoneConfig => {
-      // only create zones if configuration contains marks, otherwise just ignore it
+      // Create a new zone only if configuration contains marks
       if (zoneConfig.marks && zoneConfig.marks.length > 0) {
         return new Zone({
           onMark,

--- a/js/src/View.js
+++ b/js/src/View.js
@@ -8,13 +8,14 @@ import Zone from "./Zone";
  * @see: https://github.com/meetup/ux-capture#glossary
  */
 export default class View {
-  constructor({ onMark, onMeasure, zoneConfigs }) {
+  constructor({ onMark, onMeasure, startMark, zoneConfigs }) {
     this.expectedZones = zoneConfigs.map(zoneConfig => {
       // Create a new zone only if configuration contains marks
       if (zoneConfig.marks && zoneConfig.marks.length > 0) {
         return new Zone({
           onMark,
           onMeasure,
+          startMark,
           ...zoneConfig
         });
       }

--- a/js/src/Zone.js
+++ b/js/src/Zone.js
@@ -47,8 +47,8 @@ export default class Zone {
 
     // Mark used as starting point for subsequent UserTiming mesaures
     // For Page View (initial page loads), this will be "navigationStart"
-    // For Interactive Views, this is the mark passed in as config.startMark
-    this.startMark = config.startMark || "navigationStart";
+    // For Interactive Views, this will be "interactionStart"
+    this.startMark = config.startMark;
 
     // Create a new `ExpectedMark` for each mark
     // supplied in `config.marks`


### PR DESCRIPTION
For *Page Views*, we use the `navigationStart` User Timing mark to calculate measures.
For *Interactive Views*, we need a similar method of setting the `startMark` for each zone.

In this PR, Page Views haven't changed. For Interactive Views, you ned to do the following in the client:

```
window.UX.config({
   onMark: () => {...},
   onMeasure: () => {...},
   interactive: true,
});
...
window.UX.startTransition();
```

**** QUESTION **** 

We have a View class but at the moment it's not really doing anything. I'm not sure if the intent was to make different types of "Views" for page views and interactive views, but I'm not really doing anything with that in this PR. I could update it, but also I'm not sure how helpful it'd be. Thoughts?
