### PR TITLE
`this.marked` state for ExpectedMark to simplify `onComplete` callback

### DIFF
--- a/js/src/ExpectedMark.js
+++ b/js/src/ExpectedMark.js
@@ -1,7 +1,7 @@
 import UXBase from './UXBase';
 
-// all marks expected so far
-const _expectedMarks = [];
+// private map of { name: mark } for all expected marks
+const _expectedMarks = {};
 
 /**
  * Class describes expected marks
@@ -10,11 +10,11 @@ const _expectedMarks = [];
 export default class ExpectedMark extends UXBase {
 	// list of zone callbacks to call on completion
 	onMarkListeners = [];
-	name = this.props.name;
+	// 'state' of the mark that indicates whether it has been recorded
 	marked = false;
 
 	static get(name) {
-		return _expectedMarks.find(mark => mark.name === name);
+		return _expectedMarks[name];
 	}
 
 	/**
@@ -24,14 +24,11 @@ export default class ExpectedMark extends UXBase {
 	 * @param {string} name
 	 */
 	static create(name) {
-		let mark = ExpectedMark.get(name);
-
-		if (!mark) {
-			mark = new ExpectedMark({ name });
-			_expectedMarks.push(mark);
+		// create new mark only if one does not exist
+		if (!_expectedMarks[name]) {
+			_expectedMarks[name] = new ExpectedMark({ name });
 		}
-
-		return mark;
+		return _expectedMarks[name];
 	}
 
 	// registers zone callback
@@ -54,7 +51,7 @@ export default class ExpectedMark extends UXBase {
 			typeof window.console !== 'undefined' &&
 			typeof window.console.timeStamp !== 'undefined'
 		) {
-			window.console.timeStamp('[DEBUG] original call for ' + this.name);
+			window.console.timeStamp(`[DEBUG] original call for ${this.props.name}`);
 		}
 
 		window.requestAnimationFrame(() => setTimeout(this.record));
@@ -66,7 +63,7 @@ export default class ExpectedMark extends UXBase {
 			typeof window.performance.mark !== 'undefined'
 		) {
 			// record the mark using W3C User Timing API
-			window.performance.mark(this.name);
+			window.performance.mark(this.props.name);
 		}
 
 		/**
@@ -83,11 +80,11 @@ export default class ExpectedMark extends UXBase {
 			typeof window.console !== 'undefined' &&
 			typeof window.console.timeStamp !== 'undefined'
 		) {
-			window.console.timeStamp(this.name);
+			window.console.timeStamp(this.props.name);
 		}
 		this.marked = true;
 
 		// call all registered zone callbacks
-		this.onMarkListeners.forEach(onMarkListener => onMarkListener(this));
+		this.onMarkListeners.forEach(listener => listener(this));
 	};
 }

--- a/js/src/ExpectedMark.js
+++ b/js/src/ExpectedMark.js
@@ -1,4 +1,4 @@
-import UXBase from "./UXBase";
+import UXBase from './UXBase';
 
 // all marks expected so far
 const _expectedMarks = [];
@@ -8,86 +8,86 @@ const _expectedMarks = [];
  * These marks that have to be recorded before zone is considered complete
  */
 export default class ExpectedMark extends UXBase {
-  // list of zone callbacks to call on completion
-  onMarkListeners = [];
-  name = this.props.name;
+	// list of zone callbacks to call on completion
+	onMarkListeners = [];
+	name = this.props.name;
+	marked = false;
 
-  static get(name) {
-    return _expectedMarks.find(mark => mark.name === name);
-  }
+	static get(name) {
+		return _expectedMarks.find(mark => mark.name === name);
+	}
 
-  /**
-   * Checks if mark already exists in the list of expected marks
-   * Otherwise, creates a new one and adds it to the list
-   *
-   * @param {string} name
-   */
-  static create(name) {
-    let mark = ExpectedMark.get(name);
+	/**
+	 * Checks if mark already exists in the list of expected marks
+	 * Otherwise, creates a new one and adds it to the list
+	 *
+	 * @param {string} name
+	 */
+	static create(name) {
+		let mark = ExpectedMark.get(name);
 
-    if (!mark) {
-      mark = new ExpectedMark({ name });
-      _expectedMarks.push(mark);
-    }
+		if (!mark) {
+			mark = new ExpectedMark({ name });
+			_expectedMarks.push(mark);
+		}
 
-    return mark;
-  }
+		return mark;
+	}
 
-  // registers zone callback
-  onComplete(onMark) {
-    this.onMarkListeners.push(onMark);
-  }
+	// registers zone callback
+	onComplete(onMark) {
+		this.onMarkListeners.push(onMark);
+	}
 
-  /**
-   * This method tries to approximate full rendering lifecycle in the browser
-   * rather than just measuring JS execution like render() method does.
-   *
-   * See Nolan Lawson's article describing the issue and proposing this method:
-   * https://nolanlawson.com/2018/09/25/accurately-measuring-layout-on-the-web/
-   */
-  waitForNextPaintAndRecord() {
-    // In development mode, include DEBUG timestamps to show when
-    // original calls were fired to see the impact
-    if (
-      process.env.NODE_ENV !== "production" &&
-      typeof window.console !== "undefined" &&
-      typeof window.console.timeStamp !== "undefined"
-    ) {
-      window.console.timeStamp("[DEBUG] original call for " + this.name);
-    }
+	/**
+	 * This method tries to approximate full rendering lifecycle in the browser
+	 * rather than just measuring JS execution like render() method does.
+	 *
+	 * See Nolan Lawson's article describing the issue and proposing this method:
+	 * https://nolanlawson.com/2018/09/25/accurately-measuring-layout-on-the-web/
+	 */
+	waitForNextPaintAndRecord() {
+		// In development mode, include DEBUG timestamps to show when
+		// original calls were fired to see the impact
+		if (
+			process.env.NODE_ENV !== 'production' &&
+			typeof window.console !== 'undefined' &&
+			typeof window.console.timeStamp !== 'undefined'
+		) {
+			window.console.timeStamp('[DEBUG] original call for ' + this.name);
+		}
 
-    window.requestAnimationFrame(() => setTimeout(this.record));
-  }
+		window.requestAnimationFrame(() => setTimeout(this.record));
+	}
 
-  record = () => {
-    if (
-      typeof window.performance !== "undefined" &&
-      typeof window.performance.mark !== "undefined"
-    ) {
-      // record the mark using W3C User Timing API
-      window.performance.mark(this.name);
-    }
+	record = () => {
+		if (
+			typeof window.performance !== 'undefined' &&
+			typeof window.performance.mark !== 'undefined'
+		) {
+			// record the mark using W3C User Timing API
+			window.performance.mark(this.name);
+		}
 
-    /**
-     * Report same mark on Chrome/Firefox timeline
-     *
-     * keep in mind, these timestamps are counted from timeline recording start
-     * while UserTiming marks are counted from navigationStart event
-     * however visually, they all will be offset by the same amount of time and align vertically on the charts
-     *
-     * (we'd provide a helper to highlight discrepancy, but unfortunately,
-     * there is no way to know when in timeline did navigationStart event occured)
-     */
-    if (
-      typeof window.console !== "undefined" &&
-      typeof window.console.timeStamp !== "undefined"
-    ) {
-      window.console.timeStamp(this.name);
-    }
+		/**
+		 * Report same mark on Chrome/Firefox timeline
+		 *
+		 * keep in mind, these timestamps are counted from timeline recording start
+		 * while UserTiming marks are counted from navigationStart event
+		 * however visually, they all will be offset by the same amount of time and align vertically on the charts
+		 *
+		 * (we'd provide a helper to highlight discrepancy, but unfortunately,
+		 * there is no way to know when in timeline did navigationStart event occured)
+		 */
+		if (
+			typeof window.console !== 'undefined' &&
+			typeof window.console.timeStamp !== 'undefined'
+		) {
+			window.console.timeStamp(this.name);
+		}
+		this.marked = true;
 
-    // call all registered zone callbacks
-    this.onMarkListeners.forEach(onCompleteListener =>
-      onCompleteListener(this)
-    );
-  };
+		// call all registered zone callbacks
+		this.onMarkListeners.forEach(onMarkListener => onMarkListener(this));
+	};
 }

--- a/js/src/Zone.js
+++ b/js/src/Zone.js
@@ -48,9 +48,9 @@ export default class Zone extends UXBase {
 
 		mark.onComplete(completeMark => {
 			// pass the event upstream
-			this.onMark(completeMark.name);
+			this.onMark(markName);
 			if (this.marks.every(m => m.marked)) {
-				this.measure(completeMark);
+				this.measure(markName);
 			}
 		});
 
@@ -62,16 +62,12 @@ export default class Zone extends UXBase {
 	 *
 	 * @param {ExpectedMark} lastMark last mark that triggered completion
 	 */
-	measure(lastMark) {
+	measure(endMarkName) {
 		if (
 			typeof window.performance !== 'undefined' &&
 			typeof window.performance.measure !== 'undefined'
 		) {
-			window.performance.measure(
-				this.measureName,
-				this.startMark,
-				lastMark.name
-			);
+			window.performance.measure(this.measureName, this.startMark, endMarkName);
 		}
 
 		this.onMeasure(this.measureName);

--- a/js/src/Zone.js
+++ b/js/src/Zone.js
@@ -46,11 +46,11 @@ export default class Zone extends UXBase {
 	marks = this.props.marks.map(markName => {
 		const mark = ExpectedMark.create(markName);
 
-		mark.onComplete(mark => {
+		mark.onComplete(completeMark => {
 			// pass the event upstream
-			this.onMark(mark.name);
-			if (this.marks.every(mark => mark.marked)) {
-				this.measure(mark);
+			this.onMark(completeMark.name);
+			if (this.marks.every(m => m.marked)) {
+				this.measure(completeMark);
 			}
 		});
 

--- a/js/src/Zone.js
+++ b/js/src/Zone.js
@@ -40,12 +40,11 @@ export default class Zone extends UXBase {
 	marks = this.props.marks.map(markName => {
 		const mark = ExpectedMark.create(markName);
 
-		mark.onComplete(mark => {
-			// Call Zone's `onMark` callback
-			this.props.onMark(mark.name);
-
-			if (this.checkCompletion()) {
-				this.complete(mark);
+		mark.onComplete(completeMark => {
+			// pass the event upstream
+			this.props.onMark(markName);
+			if (this.marks.every(m => m.marked)) {
+				this.measure(markName);
 			}
 		});
 

--- a/js/src/Zone.js
+++ b/js/src/Zone.js
@@ -2,8 +2,8 @@ import ExpectedMark from './ExpectedMark';
 import UXBase from './UXBase';
 
 /**
- * A `Zone` is a collection of elements on a page that corresponds
- * to a given phase of page load. (i.e. all elements in `ux-destination-verfied`)
+ * A `Zone` is a collection of DOM elements on a page that correspond
+ * to a given phase of page load. (e.g. all elements in `ux-destination-verfied`)
  *
  * Example props:
  *
@@ -42,9 +42,6 @@ export default class Zone extends UXBase {
 
 	startMark = 'navigationStart';
 
-	// track the most recently recorded mark
-	currentMark = null;
-
 	// Create a new `ExpectedMark` for each mark
 	marks = this.props.marks.map(markName => {
 		const mark = ExpectedMark.create(markName);
@@ -52,28 +49,20 @@ export default class Zone extends UXBase {
 		mark.onComplete(mark => {
 			// pass the event upstream
 			this.onMark(mark.name);
-			this.currentMark = mark;
-			this.checkCompletion();
+			if (this.marks.every(mark => mark.marked)) {
+				this.measure(mark);
+			}
 		});
 
 		return mark;
 	});
 
 	/**
-	 * Check if all marks for the zone have already been recorded
-	 */
-	checkCompletion() {
-		if (this.marks.every(mark => mark.marked)) {
-			this.complete();
-		}
-	}
-
-	/**
 	 * Records measure on Performance Timeline and calls onMeasure callback
 	 *
 	 * @param {ExpectedMark} lastMark last mark that triggered completion
 	 */
-	complete(lastMark) {
+	measure(lastMark) {
 		if (
 			typeof window.performance !== 'undefined' &&
 			typeof window.performance.measure !== 'undefined'
@@ -81,7 +70,7 @@ export default class Zone extends UXBase {
 			window.performance.measure(
 				this.measureName,
 				this.startMark,
-				this.currentMark.name
+				lastMark.name
 			);
 		}
 

--- a/js/src/Zone.js
+++ b/js/src/Zone.js
@@ -1,5 +1,5 @@
-import ExpectedMark from "./ExpectedMark";
-import UXBase from "./UXBase";
+import ExpectedMark from './ExpectedMark';
+import UXBase from './UXBase';
 
 /**
  * A `Zone` is a collection of elements on a page that corresponds
@@ -15,84 +15,76 @@ import UXBase from "./UXBase";
  * }
  */
 export default class Zone extends UXBase {
-  /**
-   * Creates a Zone
-   * @param {object} props
-   */
-  constructor(props) {
-    super(props);
+	/**
+	 * Creates a Zone
+	 * @param {object} props
+	 */
+	constructor(props) {
+		super(props);
 
-    // Handle deprecated "label" keys
-    if (this.props.label) {
-      console.warn(
-        "[ux-capture] Deprecation Warning: `label` keys on configuration object were renamed to `name` as of verision v2.0.0",
-        "Will be removed in v3.0.0"
-      );
-    }
-  }
+		// Handle deprecated "label" keys
+		if (this.props.label) {
+			console.warn(
+				'[ux-capture] Deprecation Warning: `label` keys on configuration object were renamed to `name` as of verision v2.0.0',
+				'Will be removed in v3.0.0'
+			);
+		}
+	}
 
-  // Name used for UserTiming measures
-  measureName = this.props.name || this.props.label;
+	// Name used for UserTiming measures
+	measureName = this.props.name || this.props.label;
 
-  // Callback to execute when Zone is complete (all marks recorded)
-  onMeasure = this.props.onMeasure;
+	// Callback to execute when Zone is complete (all marks recorded)
+	onMeasure = this.props.onMeasure;
 
-  // Callback for marks to call when they are complete (recorded)
-  onMark = this.props.onMark;
+	// Callback for marks to call when they are complete (recorded)
+	onMark = this.props.onMark;
 
-  startMark = "navigationStart";
+	startMark = 'navigationStart';
 
-  // Create a new `ExpectedMark` for each mark
-  marks = this.props.marks.map(markName => {
-    const mark = ExpectedMark.create(markName);
+	// track the most recently recorded mark
+	currentMark = null;
 
-    mark.onComplete(mark => {
-      // Call Zone's `onMark` callback
-      this.onMark(mark.name);
+	// Create a new `ExpectedMark` for each mark
+	marks = this.props.marks.map(markName => {
+		const mark = ExpectedMark.create(markName);
 
-      if (this.checkCompletion()) {
-        this.complete(mark);
-      }
-    });
+		mark.onComplete(mark => {
+			// pass the event upstream
+			this.onMark(mark.name);
+			this.currentMark = mark;
+			this.checkCompletion();
+		});
 
-    return mark;
-  });
+		return mark;
+	});
 
-  /**
-   * Check if all marks for the zone have already been recorded
-   */
-  checkCompletion() {
-    if (
-      typeof window.performance === "undefined" ||
-      typeof window.performance.getEntriesByType === "undefined"
-    ) {
-      return false;
-    }
+	/**
+	 * Check if all marks for the zone have already been recorded
+	 */
+	checkCompletion() {
+		if (this.marks.every(mark => mark.marked)) {
+			this.complete();
+		}
+	}
 
-    const recordedMarks = window.performance.getEntriesByType("mark");
+	/**
+	 * Records measure on Performance Timeline and calls onMeasure callback
+	 *
+	 * @param {ExpectedMark} lastMark last mark that triggered completion
+	 */
+	complete(lastMark) {
+		if (
+			typeof window.performance !== 'undefined' &&
+			typeof window.performance.measure !== 'undefined'
+		) {
+			window.performance.measure(
+				this.measureName,
+				this.startMark,
+				this.currentMark.name
+			);
+		}
 
-    return this.marks.every(mark =>
-      recordedMarks.find(recordedMark => recordedMark.name === mark.name)
-    );
-  }
-
-  /**
-   * Records measure on Performance Timeline and calls onMeasure callback
-   *
-   * @param {ExpectedMark} lastMark last mark that triggered completion
-   */
-  complete(lastMark) {
-    if (
-      typeof window.performance !== "undefined" &&
-      typeof window.performance.measure !== "undefined"
-    ) {
-      window.performance.measure(
-        this.measureName,
-        this.startMark,
-        lastMark.name
-      );
-    }
-
-    this.onMeasure(this.measureName);
-  }
+		this.onMeasure(this.measureName);
+	}
 }


### PR DESCRIPTION
Instead of using `window.performance.getEntriesByType('mark');` to store the 'state' of recorded marks, we can store the 'marked' state of a mark in `ExpectedMark`.

This greatly simplifies the 'onComplete' handling in `Zone`, and decouples the 'marked' state from `window.performance`, which allows it to still work predictably in environments that don't support that API.