### PR TITLE
Minor docs update

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 ## [3.0.0]
-    -  **BREAKING CHANGE** Upgrade to new UXCapture api spec.
+    - **BREAKING CHANGE** Upgrade to new UXCapture api spec.
     - Module renamed from `UX` to `UXCapture`.
     - `UX.config()` renamed to `UXCapture.create()`
     - `UX.expect()` renamed to `UXCapture.startView()`
@@ -10,7 +10,7 @@
     - Move generated library JS to root /lib directory.
 
 ## [2.0.0] (October 9, 2018)
-  - BREAKING CHANGE: updated expected zone configuration to use `name` instead of `label` as key to align with timing API conventions. Update your expect calls.
+  - **BREAKING CHANGE**: updated expected zone configuration to use `name` instead of `label` as key to align with timing API conventions. Update your expect calls.
   - Now using webpack for bundling. No more source file to use, make sure to inline `js/ux-capture.min.js` file in your HTML.
   - Fixed a bug with hanging measures if mark is used in multiple places.
   - Replaced Promises with callbacks internally to simplify testing and allow for more complex logic in the future.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-## [3.0.0]
+## [3.0.0] (November 7, 2018)
     - **BREAKING CHANGE** Upgrade to new UXCapture api spec.
     - Module renamed from `UX` to `UXCapture`.
     - `UX.config()` renamed to `UXCapture.create()`

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ the `<head>`.
 2. Initialize UXCapture using `UXCapture.create()`, optionally with mark and
    measure event handlers, e.g.
 
-```html
+```jsx
     <script>
         window.UXCapture.create({
             onMark: name => console.log('marked', name),
@@ -101,7 +101,7 @@ provide a custom method of recording the results.
 3. At the top of the view markup, define the expected zones and corresponding
    marks with `UXCapture.startView()`, e.g.
 
-```html
+```jsx
     <script>
         window.UXCapture.startView([
             {
@@ -130,9 +130,9 @@ each individual name will be used when recording corresponding events as [W3C Us
 5. Call UXCapture.mark in the HTML markup for each ‘mark’ name passed into
    UXCapture.startView/updateView.
 
-```html
+```jsx
     <script>window.UXCapture.mark('ux-1')</script>
-    <img onload=”window.UXCapture.mark('ux-2')" … />
+    <img onload="window.UXCapture.mark('ux-2')" … />
     ...
 ```
 
@@ -173,7 +173,7 @@ Image tracking requires two measurements, one within the `onload` callback of
 the image itself and another within inline `<script>` tag directly after the
 image.
 
-```html
+```jsx
 <img src="hero.jpg" onload="UX.mark('ux-image-onload-logo')">
 <script>UX.mark('ux-image-inline-logo')</script>
 ```
@@ -192,7 +192,8 @@ References:
 Text that does not use a custom font can be instrumented by supplying one inline
 `<script>` tag directly after the text:
 
-```html
+```jsx
+
 <script>UX.mark("ux-text-headline");</script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,26 +19,26 @@ metrics.
 - [Testing results](#testing-results)
 - [Glossary](#glossary)
 
-<!-- /TOC -->
-
 ## Project Goals
 
 There are multiple goals for this project, many dictated by the lack of real
 rendering instrumentation of paint events in the browser. These include:
 
 - Capture display and interactivity events for various UI elements (e.g. images,
-text, video, fonts, buttons, etc.)
+  text, video, fonts, buttons, etc.)
 - Group together multiple display events for elements of a web page that
-represent the same design/product components.
+  represent the same design/product components.
 - Group together multiple components to reflect various phases of page load
-- Collect captured events and [_UX speed metrics_](#UX_speed_metrics "metrics representing speed of the human-computer interface as it is perceived by the user") for all users using
-RUM (Real User Measurement) tools.
+- Collect captured events and [_UX speed metrics_](#UX_speed_metrics 'metrics representing speed of the human-computer interface as it is perceived by the user') for all users using
+  RUM (Real User Measurement) tools.
 - Calibrate in-browser instrumentation by recording page load video using
-synthetic tools and deriving same [_UX speed metrics_](#UX_speed_metrics "metrics representing speed of the human-computer interface as it is perceived by the user")
-- Create uniform instrumentation for both [_page views_](#page_view "view resulting in full browser navigation and re-creation of browser DOM") and [_interactive views_](#interactive_view "view resulting in partial updates of browser DOM"),
-to be usable with any back-end and front-end framework
+  synthetic tools and deriving same [_UX speed metrics_](#UX_speed_metrics 'metrics representing speed of the human-computer interface as it is perceived by the user')
+- Create uniform instrumentation for both [_page views_](#page_view 'view resulting in full browser navigation and re-creation of browser DOM') and [_interactive views_](#interactive_view 'view resulting in partial updates of browser DOM'),
+  to be usable with any back-end and front-end framework
 - Future compatibility with [Element Timing API](https://github.com/w3c/charter-webperf/issues/30) that aims
-at adding instrumentation directly into browser
+  at adding instrumentation directly into browser
+
+<a id="markdown-js-library" name="js-library"></a>
 
 ## JS library
 
@@ -46,13 +46,14 @@ The intent of this library is to help developers instrument technical events
 (marks) on their pages and group them into "zones" that represent "phases" of page
 load, with each phase representing [distinct stages](#aggregating-experienceperception-phase-metrics) of user experience.
 
+<a id="markdown-usage" name="usage"></a>
+
 ### Usage
 
-WARNING: current version of the library is a first prototype that only works in
-modern browsers that support ES6 and all the necessary browser APIs.
+NOTE: this version of the library relies on `UserTiming API` to be available in the browser, but should not break if it doesn't. You can [use a polyfill](https://www.npmjs.com/package/usertiming) if you want to support older browsers.
 
 1. Load the library by inlining the contents of ux-capture.min.js in a `<script>`
-tag in the HTML document `<head>`:
+   tag in the HTML document `<head>`. Here's an example using server-side React:
 
 ```jsx
 const uxCaptureFilename = require.resolve('ux-capture/lib/ux-capture.min.js');
@@ -61,14 +62,14 @@ const uxCaptureJS = fs.readFileSync(uxCaptureFilename, 'utf8');
 render() {
     <head>
         <title>My Page</title>
-        <script dangerouslySetInnerHTML={getInnerHTML(uxCaptureJS)} />
+        <script dangerouslySetInnerHTML={{ __html: uxCaptureJS }} />
         ...
     </head>
     ...
 }
 ```
 
-**NOTE**: The script must be inlined. Do use a script tag with a `src` attribute.
+**NOTE**: The script must be inlined. Do not use a script tag with a `src` attribute.
 Waiting for network requests might artifically skew event timings on the page
 and lead to race conditions.
 
@@ -77,9 +78,9 @@ we need to instrument events that happen as early as HTML parsing, so ideally in
 the `<head>`.
 
 2. Initialize UXCapture using `UXCapture.create()`, optionally with mark and
-measure event handlers, e.g.
+   measure event handlers, e.g.
 
-```jsx
+```html
     <script>
         window.UXCapture.create({
             onMark: name => console.log('marked', name),
@@ -93,14 +94,14 @@ Custom event handlers are useful in cases where the monitoring solution you use
 provide a custom method of recording the results.
 
 - `onMark` - provides a custom handler to be called every time a mark is recorded
-with the name of the mark as the only argument
+  with the name of the mark as the only argument
 - `onMeasure` - provides a custom handler to be called every time a measure is
-recorded with the name of the measure as the only argument
+  recorded with the name of the measure as the only argument
 
 3. At the top of the view markup, define the expected zones and corresponding
-marks with `UXCapture.startView()`, e.g.
+   marks with `UXCapture.startView()`, e.g.
 
-```js
+```html
     <script>
         window.UXCapture.startView([
             {
@@ -124,16 +125,18 @@ used as a name of corresponding [W3C UserTiming API `measure`](https://www.w3.or
 each individual name will be used when recording corresponding events as [W3C UserTiming API `mark`](https://www.w3.org/TR/user-timing/#performancemark).
 
 4. You can optionally update a view that has already been started and add more
-zones by calling `UXCapture.updateView()`.
+   zones by calling `UXCapture.updateView()`.
 
 5. Call UXCapture.mark in the HTML markup for each ‘mark’ name passed into
-UXCapture.startView/updateView.
+   UXCapture.startView/updateView.
 
-```javascript
+```html
     <script>window.UXCapture.mark('ux-1')</script>
-    <img onload=”window.UXCapture.mark('ux-2') … />
+    <img onload=”window.UXCapture.mark('ux-2')" … />
     ...
 ```
+
+<a id="markdown-sample-page" name="sample-page"></a>
 
 ### Sample page
 
@@ -141,7 +144,11 @@ This repository contains a sample page that implements basic instrumentation
 for your reference:
 https://cdn.rawgit.com/sergeychernyshev/ux-capture/master/examples/index.html
 
+<a id="markdown-instrumentation" name="instrumentation"></a>
+
 ## Instrumentation
+
+<a id="markdown-individual-element-instrumentation" name="individual-element-instrumentation"></a>
 
 ### Individual Element Instrumentation
 
@@ -158,13 +165,15 @@ instrumenting the display timings in modern browsers.
 
 Below is the list of instrumentation methods with examples:
 
+<a id="markdown-image-elements" name="image-elements"></a>
+
 #### Image elements
 
 Image tracking requires two measurements, one within the `onload` callback of
 the image itself and another within inline `<script>` tag directly after the
 image.
 
-```javascript
+```html
 <img src="hero.jpg" onload="UX.mark('ux-image-onload-logo')">
 <script>UX.mark('ux-image-inline-logo')</script>
 ```
@@ -176,12 +185,14 @@ References:
 
 - Steve Souders: [Hero Image Custom Metrics](https://www.stevesouders.com/blog/2015/05/12/hero-image-custom-metrics/), published on May 12, 2015
 
+<a id="markdown-text-without-custom-font" name="text-without-custom-font"></a>
+
 #### Text without custom font
 
 Text that does not use a custom font can be instrumented by supplying one inline
 `<script>` tag directly after the text:
 
-```javascript
+```html
 <script>UX.mark("ux-text-headline");</script>
 ```
 
@@ -191,6 +202,8 @@ References:
 
 - Steve Souders: [User Timing and Custom Metrics](https://speedcurve.com/blog/user-timing-and-custom-metrics/) (example 5), published on November 12, 2015
 
+<a id="markdown-event-handler-attachment" name="event-handler-attachment"></a>
+
 #### Event handler attachment
 
 Some user activity requires custom JavaScript handler code to be attached to an
@@ -199,12 +212,14 @@ visible AND clickable). Instrumenting handler attachment is straightforward, jus
 include the call right after handler attachment in JavaScript code.
 
 ```javascript
-var button_element = document.getElementById("mybutton");
-button_element.addEventListener("click", myActionHandler);
-UX.mark("ux-handler-myaction");
+var button_element = document.getElementById('mybutton');
+button_element.addEventListener('click', myActionHandler);
+UX.mark('ux-handler-myaction');
 ```
 
 Element aggregation algorythm: no aggregation, just one event.
+
+<a id="markdown-aggregating-component-metrics" name="aggregating-component-metrics"></a>
 
 ### Aggregating component metrics
 
@@ -225,6 +240,8 @@ Component-level aggregation might be an advanced detail and can be skipped early
 on with element timings aggregated directly into experience/perception phases,
 but can be useful for modularity and more detailed analysis across the system.
 
+<a id="markdown-aggregating-experienceperception-phase-metrics" name="aggregating-experienceperception-phase-metrics"></a>
+
 ### Aggregating experience/perception phase metrics
 
 It is critical to group metrics into categories that are not specific to individual
@@ -233,7 +250,7 @@ different components / elements on each page.
 
 Well known example of such "category" is **_first meaningful paint_** which has
 different meaning on differeng parts of user experience, but represents a universal
-improvement over "first paint" [_technical metric_](#technical_performance_metrics "performance metrics that represent time spent executing various technical components of the application as opposed to metrics representing speed of the human-computer interface as it is perceived by the user").
+improvement over "first paint" [_technical metric_](#technical_performance_metrics 'performance metrics that represent time spent executing various technical components of the application as opposed to metrics representing speed of the human-computer interface as it is perceived by the user').
 
 This can be taken further to represent user's intent in more detail. Each view
 can be broken down into several phases which all contribute to keeping user on
@@ -251,7 +268,7 @@ Each phase's component or element metrics (marks) can be combined and reported a
 
 ```javascript
 // assuming logo's onload event was last to fire among all element timers for this phase
-performance.measure("ux-destination-verified", 0, "ux-image-onload-logo");
+performance.measure('ux-destination-verified', 0, 'ux-image-onload-logo');
 ```
 
 the can be then collected using RUM beacon or using synthetic testing tool like
@@ -259,6 +276,8 @@ WebPageTest or [Chrome Developer Tools' Timeline tab](https://twitter.com/igrigo
 
 This is done automatically by the library and no additional instrumentation is
 necessary.
+
+<a id="markdown-testing-results" name="testing-results"></a>
 
 ## Testing results
 
@@ -280,6 +299,8 @@ You can also run W3C Performance Timeline API [`performance.getEntriesByType()`]
 method with `"mark"` and `"measure"` parameters to retrieve marks and measures respectively.
 
 ![Chrome DevTools console showing captured performance marks and measures](docs/basic-results-sample-chromedevtools-console.png)
+
+<a id="markdown-glossary" name="glossary"></a>
 
 ## Glossary
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 Browser instrumentation library that makes it easier to capture UX performance
 metrics.
 
-<!-- TOC depthFrom:2 depthTo:6 orderedList:false updateOnSave:true withLinks:true -->
-
 - [Project Goals](#project-goals)
 - [JS library](#js-library)
   - [Usage](#usage)

--- a/README.md
+++ b/README.md
@@ -38,15 +38,11 @@ rendering instrumentation of paint events in the browser. These include:
 - Future compatibility with [Element Timing API](https://github.com/w3c/charter-webperf/issues/30) that aims
   at adding instrumentation directly into browser
 
-<a id="markdown-js-library" name="js-library"></a>
-
 ## JS library
 
 The intent of this library is to help developers instrument technical events
 (marks) on their pages and group them into "zones" that represent "phases" of page
 load, with each phase representing [distinct stages](#aggregating-experienceperception-phase-metrics) of user experience.
-
-<a id="markdown-usage" name="usage"></a>
 
 ### Usage
 
@@ -136,19 +132,13 @@ each individual name will be used when recording corresponding events as [W3C Us
     ...
 ```
 
-<a id="markdown-sample-page" name="sample-page"></a>
-
 ### Sample page
 
 This repository contains a sample page that implements basic instrumentation
 for your reference:
 https://cdn.rawgit.com/sergeychernyshev/ux-capture/master/examples/index.html
 
-<a id="markdown-instrumentation" name="instrumentation"></a>
-
 ## Instrumentation
-
-<a id="markdown-individual-element-instrumentation" name="individual-element-instrumentation"></a>
 
 ### Individual Element Instrumentation
 
@@ -164,8 +154,6 @@ in industry white papers or blogs as there is currently no direct method of
 instrumenting the display timings in modern browsers.
 
 Below is the list of instrumentation methods with examples:
-
-<a id="markdown-image-elements" name="image-elements"></a>
 
 #### Image elements
 
@@ -185,15 +173,12 @@ References:
 
 - Steve Souders: [Hero Image Custom Metrics](https://www.stevesouders.com/blog/2015/05/12/hero-image-custom-metrics/), published on May 12, 2015
 
-<a id="markdown-text-without-custom-font" name="text-without-custom-font"></a>
-
 #### Text without custom font
 
 Text that does not use a custom font can be instrumented by supplying one inline
 `<script>` tag directly after the text:
 
 ```jsx
-
 <script>UX.mark("ux-text-headline");</script>
 ```
 
@@ -202,8 +187,6 @@ Element aggregation algorythm: no aggregation, just one event.
 References:
 
 - Steve Souders: [User Timing and Custom Metrics](https://speedcurve.com/blog/user-timing-and-custom-metrics/) (example 5), published on November 12, 2015
-
-<a id="markdown-event-handler-attachment" name="event-handler-attachment"></a>
 
 #### Event handler attachment
 
@@ -219,8 +202,6 @@ UX.mark('ux-handler-myaction');
 ```
 
 Element aggregation algorythm: no aggregation, just one event.
-
-<a id="markdown-aggregating-component-metrics" name="aggregating-component-metrics"></a>
 
 ### Aggregating component metrics
 
@@ -240,8 +221,6 @@ although these are less common and can create more variability in measurement.
 Component-level aggregation might be an advanced detail and can be skipped early
 on with element timings aggregated directly into experience/perception phases,
 but can be useful for modularity and more detailed analysis across the system.
-
-<a id="markdown-aggregating-experienceperception-phase-metrics" name="aggregating-experienceperception-phase-metrics"></a>
 
 ### Aggregating experience/perception phase metrics
 
@@ -278,8 +257,6 @@ WebPageTest or [Chrome Developer Tools' Timeline tab](https://twitter.com/igrigo
 This is done automatically by the library and no additional instrumentation is
 necessary.
 
-<a id="markdown-testing-results" name="testing-results"></a>
-
 ## Testing results
 
 To confirm that your instrumentation was successful, open your page in Chrome
@@ -300,8 +277,6 @@ You can also run W3C Performance Timeline API [`performance.getEntriesByType()`]
 method with `"mark"` and `"measure"` parameters to retrieve marks and measures respectively.
 
 ![Chrome DevTools console showing captured performance marks and measures](docs/basic-results-sample-chromedevtools-console.png)
-
-<a id="markdown-glossary" name="glossary"></a>
 
 ## Glossary
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ event on the page, e.g. `click` of the button (e.g. it's only "available" when
 visible AND clickable). Instrumenting handler attachment is straightforward, just
 include the call right after handler attachment in JavaScript code.
 
-```javascript
+```jsx
 var button_element = document.getElementById('mybutton');
 button_element.addEventListener('click', myActionHandler);
 UX.mark('ux-handler-myaction');
@@ -244,7 +244,7 @@ different perspectives:
 
 Each phase's component or element metrics (marks) can be combined and reported as measures:
 
-```javascript
+```jsx
 // assuming logo's onload event was last to fire among all element timers for this phase
 performance.measure('ux-destination-verified', 0, 'ux-image-onload-logo');
 ```


### PR DESCRIPTION
- Unify BREAKING CHANGE presentation in CHANGELOG, added v3 release data
- Clarify JSX code usage in head injection example, removed missing `getInnerHTML()` function usage
- Switched all code block formatters to JSX to unify them

Also some automated re-formatting by Prettier/VSCode/god knows what else...