### PR TITLE
WP-974 Showing transitionStart marks on the list of marks and measures. 

### DIFF
--- a/packages/react-ux-capture-example/src/App.jsx
+++ b/packages/react-ux-capture-example/src/App.jsx
@@ -35,7 +35,7 @@ class App extends Component {
 					.filter(entry => entry.name === name)
 					.pop();
 
-				if (measure.duration) {
+				if (measure) {
 					// in real world you might be sending this to your custom monitoring solution
 					// (because it does not support W3C UserTiming API natively)
 					this.setState(state => ({
@@ -156,7 +156,14 @@ class App extends Component {
 													</div>
 													{measure.name !==
 														'transitionStart' && (
-														<div className="flex-item">
+														<div
+															className="flex-item"
+															style={
+																measure.duration < 0
+																	? { color: 'red' }
+																	: {}
+															}
+														>
 															<span
 																role="img"
 																aria-label="Time duration icon"

--- a/packages/react-ux-capture-example/src/App.jsx
+++ b/packages/react-ux-capture-example/src/App.jsx
@@ -115,7 +115,12 @@ class App extends Component {
 														{mark.name}
 													</div>
 													<div className="flex-item">
-														🕒{' '}
+														<span
+															role="img"
+															aria-label="Moment in time icon"
+														>
+															🕒
+														</span>{' '}
 														{Math.round(
 															mark.startTime * 10
 														) / 10}
@@ -152,7 +157,12 @@ class App extends Component {
 													{measure.name !==
 														'transitionStart' && (
 														<div className="flex-item">
-															🕒{' '}
+															<span
+																role="img"
+																aria-label="Time duration icon"
+															>
+																⌛
+															</span>{' '}
 															{Math.round(
 																measure.duration * 10
 															) / 10}

--- a/packages/react-ux-capture-example/src/Foo.jsx
+++ b/packages/react-ux-capture-example/src/Foo.jsx
@@ -2,11 +2,8 @@ import React from 'react';
 import Inline from './marks/Inline';
 import Page from './Page';
 
-const destinationVerified = [
-	'ux-text-foo-title',
-	'ux-image-onload-script-logo',
-];
-const primaryContentDisplayed = ['ux-text-home-primary'];
+const destinationVerified = ['ux-text-foo-title', 'ux-image-onload-script-logo'];
+const primaryContentDisplayed = ['ux-text-foo-primary'];
 const secondaryContentDisplayed = ['ux-text-foo-secondary'];
 const primaryActionAvailable = ['ux-button-foo-primary'];
 const Foo = () => (
@@ -23,8 +20,8 @@ const Foo = () => (
 		<div className="chunk">
 			<p>
 				Primary content paragraph. All content in this view is loaded
-				synchronously - the measures correspond to the client-side app rendering
-				time
+				synchronously - the measures correspond to the client-side app
+				rendering time
 			</p>
 			<Inline mark="ux-text-foo-primary" />
 		</div>

--- a/packages/react-ux-capture-example/src/Home.jsx
+++ b/packages/react-ux-capture-example/src/Home.jsx
@@ -1,15 +1,21 @@
 import React from 'react';
 
+import UXCaptureImageLoad from '@meetup/react-ux-capture/lib/UXCaptureImageLoad';
+
 import Inline from './marks/Inline';
 import Page from './Page';
 
-const destinationVerified = [
-	'ux-text-home-title',
-	'ux-image-onload-script-logo',
+import MarkInfo from './marks/MarkInfo';
+
+const destinationVerified = ['ux-image-onload-script-logo'];
+const primaryContentDisplayed = [
+	'ux-text-home-copy',
+	'ux-image-inline-kitten250',
+	'ux-image-onload-kitten250',
 ];
-const primaryContentDisplayed = ['ux-text-home-primary'];
+const primaryActionAvailable = ['ux-handler-home-button'];
 const secondaryContentDisplayed = ['ux-text-home-secondary'];
-const primaryActionAvailable = ['ux-button-home-primary'];
+
 const Home = () => (
 	<Page
 		destinationVerified={destinationVerified}
@@ -18,20 +24,27 @@ const Home = () => (
 		primaryActionAvailable={primaryActionAvailable}
 	>
 		<div className="chunk">
-			<h1 className="text--pageTitle">Home Title</h1>
-			<Inline mark="ux-text-home-title" />
+			<UXCaptureImageLoad
+				mark="ux-image-onload-kitten250"
+				src="http://placekitten.com/250/250"
+				alt="kitten"
+				width="250"
+				height="250"
+			/>
+			<MarkInfo mark="ux-image-onload-kitten250" />
+			<Inline mark="ux-image-inline-kitten250" />
 		</div>
 		<div className="chunk">
 			<p>
 				Primary content paragraph. All content in this view is loaded
-				synchronously - the measures correspond to the client-side app rendering
-				time
+				synchronously - the measures correspond to the client-side app
+				rendering time
 			</p>
-			<Inline mark="ux-text-home-primary" />
+			<Inline mark="ux-text-home-copy" />
 		</div>
 		<div className="chunk">
 			<button>Primary action button</button>
-			<Inline mark="ux-button-home-primary" />
+			<Inline mark="ux-handler-home-button" />
 		</div>
 		<div className="chunk">
 			<p>Secondary content paragraph</p>

--- a/packages/react-ux-capture-example/src/marks/Inline.jsx
+++ b/packages/react-ux-capture-example/src/marks/Inline.jsx
@@ -8,7 +8,9 @@ const Inline = props => {
 	return (
 		<React.Fragment>
 			<PerfContext.Consumer>
-				{({ marks }) => <MarkInfo mark={marks.find(m => m === mark)} />}
+				{({ marks }) => (
+					<MarkInfo mark={marks.find(m => m.name === mark) ? mark : null} />
+				)}
 			</PerfContext.Consumer>
 			<UXCaptureInlineMark mark={mark} />
 		</React.Fragment>

--- a/packages/react-ux-capture-example/src/marks/MarkInfo.jsx
+++ b/packages/react-ux-capture-example/src/marks/MarkInfo.jsx
@@ -18,7 +18,12 @@ export default props => {
 			className="flex text--secondary text--small border--top border--bottom"
 		>
 			<div className="flex-item">{mark.name}</div>
-			<div className="flex-item">🕒 {mark.startTime}ms</div>
+			<div className="flex-item">
+				<span role="img" aria-label="Moment in time icon">
+					🕒
+				</span>{' '}
+				{mark.startTime}ms
+			</div>
 		</div>
 	);
 };

--- a/packages/react-ux-capture-example/src/marks/MarkInfo.jsx
+++ b/packages/react-ux-capture-example/src/marks/MarkInfo.jsx
@@ -1,19 +1,24 @@
 import React from 'react';
 
-const getTime = name => {
+const getMark = name => {
 	const mark = window.performance.getEntriesByName(name).pop();
-	return mark ? Math.round(mark.startTime * 10) / 10 : null;
+
+	return {
+		name: name,
+		startTime: mark ? Math.round(mark.startTime * 10) / 10 : null,
+	};
 };
 
 export default props => {
-	const time = getTime(props.mark);
+	const mark = getMark(props.mark);
+
 	return (
 		<div
 			style={{ maxWidth: '600px' }}
 			className="flex text--secondary text--small border--top border--bottom"
 		>
-			<div className="flex-item">{props.mark}</div>
-			<div className="flex-item">🕒 {time}ms</div>
+			<div className="flex-item">{mark.name}</div>
+			<div className="flex-item">🕒 {mark.startTime}ms</div>
 		</div>
 	);
 };

--- a/packages/ux-capture/src/UXCapture.js
+++ b/packages/ux-capture/src/UXCapture.js
@@ -8,7 +8,7 @@ const NOOP = () => {};
  *
  * See: https://github.com/w3c/user-timing/issues/22
  */
-const NAVIGATION_START_MARK_NAME = 'navigationStart';
+export const NAVIGATION_START_MARK_NAME = 'navigationStart';
 /**
  * Used to mark start of interactive view
  */


### PR DESCRIPTION
Also added view-specific image.

Also made destination verified zone on home be only a logo making it fully ready for transition which showcases a bug (should be 0 duration, but shows a negative duration instead).

JIRA: https://meetup.atlassian.net/browse/WP-974