### PR TITLE
WP-975 Fix for negative measure duration on transition

### DIFF
--- a/packages/react-ux-capture-example/src/App.jsx
+++ b/packages/react-ux-capture-example/src/App.jsx
@@ -35,7 +35,7 @@ class App extends Component {
 					.filter(entry => entry.name === name)
 					.pop();
 
-				if (measure.duration) {
+				if (measure) {
 					// in real world you might be sending this to your custom monitoring solution
 					// (because it does not support W3C UserTiming API natively)
 					this.setState(state => ({
@@ -156,7 +156,14 @@ class App extends Component {
 													</div>
 													{measure.name !==
 														'transitionStart' && (
-														<div className="flex-item">
+														<div
+															className="flex-item"
+															style={
+																measure.duration < 0
+																	? { color: 'red' }
+																	: {}
+															}
+														>
 															<span
 																role="img"
 																aria-label="Time duration icon"

--- a/packages/ux-capture/src/UXCapture.js
+++ b/packages/ux-capture/src/UXCapture.js
@@ -8,7 +8,7 @@ const NOOP = () => {};
  *
  * See: https://github.com/w3c/user-timing/issues/22
  */
-const NAVIGATION_START_MARK_NAME = 'navigationStart';
+export const NAVIGATION_START_MARK_NAME = 'navigationStart';
 /**
  * Used to mark start of interactive view
  */


### PR DESCRIPTION
Record zero duration UserTiming measures when zone is fully satisfied at the moment of transition.

JIRA: https://meetup.atlassian.net/browse/WP-975