### PR TITLE
Support inline img style

### DIFF
--- a/packages/react-ux-capture-example/src/views/Basic.jsx
+++ b/packages/react-ux-capture-example/src/views/Basic.jsx
@@ -38,6 +38,7 @@ const Basic = () => (
 				alt="kitten"
 				width="250"
 				height="250"
+				style={{ backgroundColor: 'blue', marginTop: '10px' }}
 			/>
 			<UXCaptureInlineMark mark="ux-image-inline-kitten" />
 		</div>

--- a/packages/react-ux-capture/src/UXCaptureImageLoad.jsx
+++ b/packages/react-ux-capture/src/UXCaptureImageLoad.jsx
@@ -42,7 +42,7 @@ export const getPropsAsHTMLAttrs = (props: React$ElementProps<'img'>): string =>
 		.join(' ');
 };
 
-export const getCSSTermNamesFromStyleObject = style => {
+export const getCSSStringFromStyleObject = style => {
 	return style
 		? Object.keys(style)
 				.map(s => {
@@ -65,14 +65,14 @@ const UXCaptureImageLoad = (props: Props) => {
 	const otherImgAttrs = getPropsAsHTMLAttrs(other);
 
 	const inlineStyles = style
-		? `style="${getCSSTermNamesFromStyleObject(style)}""`
+		? `style="${getCSSStringFromStyleObject(style)}""`
 		: '';
 
 	return (
 		<div
 			dangerouslySetInnerHTML={{
 				__html: `
-				<img id="ux-capture-${mark}" src="${src}" onload="${onload}" ${inlineStyles} ${otherImgAttrs} />
+				<img src="${src}" onload="${onload}" ${inlineStyles} ${otherImgAttrs} />
 			`,
 			}}
 		/>

--- a/packages/react-ux-capture/src/UXCaptureImageLoad.jsx
+++ b/packages/react-ux-capture/src/UXCaptureImageLoad.jsx
@@ -42,6 +42,17 @@ export const getPropsAsHTMLAttrs = (props: React$ElementProps<'img'>): string =>
 		.join(' ');
 };
 
+export const getCSSTermNamesFromStyleObject = style => {
+	return style
+		? Object.keys(style)
+				.map(s => {
+					const key = s.replace(/([A-Z])/g, v => `-${v[0].toLowerCase()}`);
+					return `${key}:${style[s]}`;
+				})
+				.join(';')
+		: '';
+};
+
 /**
  * Creates an image tag with provide props
  * and a UXCapture `onLoad` handler
@@ -49,16 +60,19 @@ export const getPropsAsHTMLAttrs = (props: React$ElementProps<'img'>): string =>
  * @see example https://github.com/meetup/ux-capture#image-elements
  */
 const UXCaptureImageLoad = (props: Props) => {
-	const { mark, src, ...other } = props;
-
+	const { mark, src, style, ...other } = props;
 	const onload = getOnLoadJS(mark);
 	const otherImgAttrs = getPropsAsHTMLAttrs(other);
+
+	const inlineStyles = style
+		? `style="${getCSSTermNamesFromStyleObject(style)}""`
+		: '';
 
 	return (
 		<div
 			dangerouslySetInnerHTML={{
 				__html: `
-				<img id="ux-capture-${mark}" src="${src}" onload="${onload}" ${otherImgAttrs} />
+				<img id="ux-capture-${mark}" src="${src}" onload="${onload}" ${inlineStyles} ${otherImgAttrs} />
 			`,
 			}}
 		/>


### PR DESCRIPTION
This PR is at least suited for demonstrating the problem and a_possible_ solution, but likely not the best. Given the use of `dangerouslySetInnerHTML`, I'm not immediately sure of a better option.

Note that the reason this doesn't currently work is because this line results in a style attribute whose value is the `toString()` of the object, so something like `style="[object Object]"`.