### PR TITLE
170365387 Don't throw an exception when `transitionStart` is missing

### DIFF
--- a/packages/ux-capture/package.json
+++ b/packages/ux-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meetup/ux-capture",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "Browser instrumentation helper that makes it easier to capture UX speed metrics",
   "main": "lib/ux-capture.min.js",
   "directories": {

--- a/packages/ux-capture/src/Zone.js
+++ b/packages/ux-capture/src/Zone.js
@@ -72,7 +72,10 @@ Zone.prototype.measure = function(triggerName) {
 				? startMarkName
 				: triggerName;
 
-		window.performance.measure(name, startMarkName, endMarkName);
+		// do not to attempt recording measure without a valid start point
+		if (startMarkName === 'navigationStart' || startMark) {
+			window.performance.measure(name, startMarkName, endMarkName);
+		}
 	}
 
 	this.measured = true;


### PR DESCRIPTION
Test and fix for a bug when we attempt to record a measure without a `transitionStart` mark on interactive transitions.

Things are complicated by the fact that our tests use UserTiming polyfill which does not throw an exception if start mark does not exist (real browsers do).

Closes https://www.pivotaltracker.com/story/show/170365387