### PR TITLE
Fix: Fire on mark callback only once

### DIFF
--- a/packages/ux-capture/package.json
+++ b/packages/ux-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meetup/ux-capture",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "Browser instrumentation helper that makes it easier to capture UX speed metrics",
   "main": "lib/ux-capture.min.js",
   "directories": {

--- a/packages/ux-capture/src/ExpectedMark.js
+++ b/packages/ux-capture/src/ExpectedMark.js
@@ -20,10 +20,15 @@ function ExpectedMark(props) {
  *
  * @param {string} name
  */
-ExpectedMark.create = function(name) {
+ExpectedMark.create = function(name, listener) {
 	// create new mark only if one does not exist
 	if (!_expectedMarks[name]) {
-		_expectedMarks[name] = new ExpectedMark({ name });
+		var mark = new ExpectedMark({ name });
+		if (listener) {
+			mark.addOnMarkListener(listener);
+		}
+
+		_expectedMarks[name] = mark;
 	}
 	return _expectedMarks[name];
 };

--- a/packages/ux-capture/src/Zone.js
+++ b/packages/ux-capture/src/Zone.js
@@ -22,20 +22,24 @@ function Zone(props) {
 	this.marks = this.props.marks.map(markName => {
 		// 'state' of the measure that indicates whether it has been recorded
 		this.measured = false;
-		const mark = ExpectedMark.create(markName);
 
-		const listener = completeMark => {
+		const markListener = completeMark => {
 			// pass the event upstream
 			this.props.onMark(markName);
+		};
+
+		const mark = ExpectedMark.create(markName, markListener);
+
+		const measureListener = completeMark => {
 			if (this.marks.every(({ mark }) => mark.marked)) {
 				this.measure(markName);
 			}
 		};
 
-		return { mark, listener };
+		return { mark, measureListener };
 	});
-	this.marks.forEach(({ mark, listener }) => {
-		mark.addOnMarkListener(listener);
+	this.marks.forEach(({ mark, measureListener }) => {
+		mark.addOnMarkListener(measureListener);
 	});
 }
 
@@ -90,7 +94,9 @@ Zone.prototype.destroy = function() {
 		window.performance.clearMeasures(this.props.name);
 	}
 	// don't destroy the ExpectedMarks, because they may outlive a View/Zone, just remove reference
-	this.marks.forEach(({ mark, listener }) => mark.removeOnMarkListener(listener));
+	this.marks.forEach(({ mark, measureListener }) =>
+		mark.removeOnMarkListener(measureListener)
+	);
 	this.marks = null;
 };
 

--- a/packages/ux-capture/test/uxCapture.test.js
+++ b/packages/ux-capture/test/uxCapture.test.js
@@ -43,16 +43,19 @@ function spyConsole() {
 }
 
 describe('UXCapture', () => {
-	describe('startView', () => {
-		beforeEach(() => {
-			onMark.mockClear();
-			onMeasure.mockClear();
-			UXCapture.create({ onMark, onMeasure });
-		});
-		afterEach(() => {
-			UXCapture.destroy();
-		});
+	beforeEach(() => {
+		onMark.mockClear();
+		onMeasure.mockClear();
+		UXCapture.create({ onMark, onMeasure });
+		window.performance.clearMarks();
+		window.performance.clearMeasures();
+	});
 
+	afterEach(() => {
+		UXCapture.destroy();
+	});
+
+	describe('startView', () => {
 		// not needed after WP-945
 		it('must create dependencies between marks and measures', () => {
 			UXCapture.startView([
@@ -106,14 +109,6 @@ describe('UXCapture', () => {
 	});
 
 	describe('create', () => {
-		beforeEach(() => {
-			onMark.mockClear();
-			onMeasure.mockClear();
-		});
-		afterEach(() => {
-			UXCapture.destroy();
-		});
-
 		it('Should throw an error if non-object is passed', () => {
 			expect(() => {
 				UXCapture.create();
@@ -184,10 +179,6 @@ describe('UXCapture', () => {
 
 	describe('mark', () => {
 		beforeEach(() => {
-			onMark.mockClear();
-			onMeasure.mockClear();
-			UXCapture.create({ onMark, onMeasure });
-
 			UXCapture.startView([
 				{
 					name: MOCK_MEASURE_1,
@@ -202,10 +193,6 @@ describe('UXCapture', () => {
 					marks: [MOCK_MARK_MULTIPLE],
 				},
 			]);
-		});
-
-		afterEach(() => {
-			UXCapture.destroy();
 		});
 
 		it('must mark user timing api timeline', () => {
@@ -280,15 +267,6 @@ describe('UXCapture', () => {
 	});
 
 	describe('startTransition', () => {
-		beforeEach(() => {
-			onMark.mockClear();
-			onMeasure.mockClear();
-			UXCapture.create({ onMark, onMeasure });
-		});
-		afterEach(() => {
-			UXCapture.destroy();
-		});
-
 		it('destroys current view', () => {
 			// page view
 			spyOn(View.prototype, 'destroy');
@@ -305,9 +283,6 @@ describe('UXCapture', () => {
 		});
 
 		it('should not attempt to record a measure if transitionStart mark does not exist in interactive views', () => {
-			window.performance.clearMarks();
-			window.performance.clearMeasures();
-
 			UXCapture.startTransition();
 
 			expect(

--- a/packages/ux-capture/test/uxCapture.test.js
+++ b/packages/ux-capture/test/uxCapture.test.js
@@ -264,6 +264,20 @@ describe('UXCapture', () => {
 					.find(measure => measure.name === MOCK_MEASURE_1)
 			).toBeTruthy();
 		});
+
+		it('must only call onMark callback once per mark even if it is used in multiple zones', () => {
+			UXCapture.mark(MOCK_MARK_MULTIPLE);
+
+			expect(onMark).toHaveBeenCalledTimes(1);
+		});
+
+		it('must call onMark the same number of times as UXCapture.mark() method calls', () => {
+			UXCapture.mark(MOCK_MARK_1_1);
+			UXCapture.mark(MOCK_MARK_MULTIPLE);
+			UXCapture.mark(MOCK_MARK_MULTIPLE);
+
+			expect(onMark).toHaveBeenCalledTimes(3);
+		});
 	});
 
 	describe('startTransition', () => {


### PR DESCRIPTION
If mark is used as part of multiple zones, onMark callback is fired multiple times even if UXCapture.mark() method was only called once.

This PR fixes this and adds tests for this.

Ticket: https://www.pivotaltracker.com/story/show/170635224